### PR TITLE
Fix: Updated tests for updateTokenRateLimitParams

### DIFF
--- a/src/core/Guardian.sol
+++ b/src/core/Guardian.sol
@@ -155,6 +155,9 @@ contract Guardian is IGuardian {
         uint256 _withdrawalPeriod,
         uint256 _minAmount
     ) external onlyAdmin {
+        if (_minLiquidityThreshold == 0 || _minLiquidityThreshold > BPS_DENOMINATOR) {
+            revert InvalidMinimumLiquidityThreshold();
+        }
         TokenRateLimitInfo storage token = tokenRateLimitInfo[_token];
         if (token.minLiquidityTreshold == 0) revert TokenDoesNotExist();
         token.minLiquidityTreshold = _minLiquidityThreshold;

--- a/test/core/Guardian.t.sol
+++ b/test/core/Guardian.t.sol
@@ -87,6 +87,14 @@ contract GuadianTest is Test {
         vm.prank(admin);
         vm.expectRevert(Guardian.InvalidMinimumLiquidityThreshold.selector);
         guardian.registerToken(address(secondToken), 10_001, 4 hours, 1000e18);
+
+        vm.prank(admin);
+        vm.expectRevert(Guardian.InvalidMinimumLiquidityThreshold.selector);
+        guardian.updateTokenRateLimitParams(address(secondToken), 0, 5 hours, 2000e18);
+
+        vm.prank(admin);
+        vm.expectRevert(Guardian.InvalidMinimumLiquidityThreshold.selector);
+        guardian.updateTokenRateLimitParams(address(secondToken), 10_001, 5 hours, 2000e18);
     }
 
     function testRegisterTokenWhenAlreadyRegisteredShouldFail() public {


### PR DESCRIPTION
Added a missed check for `_minLiquidityThreshold` in Guardian contract.
Added the tests related to it.