### PR TITLE
Native asset support for inflow and outflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ contract MockDeFiConsumer {
 
     error RateLimited();
 
-    function outflowHook(address token, uint256 amount) external {
-        defi.outflowHook(address token, uint256 amount);
+    function onTokenOutflow(address token, uint256 amount) external {
+        defi.onTokenOutflow(address token, uint256 amount);
         if(circuitBreaker.isRateLimited()){
             revert RateLimited()
         }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# DeFi CircuitBreaker: Token rate-limits for your DeFi Protocol
+# DeFi Circuit Breaker: Token Rate-limits for your DeFi Protocol
 
 ## Features
 
-- Protocol Agnositic approach to token rate limiting
+- Protocol Agnositic approach to ERC20/Native rate-limiting
 - Performant Codebase
 - Multiple tokens supports with custom withdrawal rate limits for each token.
 - Records inflows/outflows of token and maintains a Historical running total of the protocol's token liquidity.
@@ -13,9 +13,10 @@
 
 There are easy points of integration that you must do to have your protocol circuitBreaker properly set up.
 
-1. Register tokens if applicable
-2. Add contracts to circuit breaker
-3. use 'ProtectedContract's internal functions to move funds out of the protocol (not needed for moving assets within your protocol's contracts)
+1. Instantiate Circuit Breaker contract with appropriate constructor params
+2. Register circuit breaker params for each desired token
+3. Add protected contracts to circuit breaker
+4. Enjoy enhanced safety
 
 #### Example CircuitBreaker Integration
 

--- a/src/core/CircuitBreaker.sol
+++ b/src/core/CircuitBreaker.sol
@@ -232,7 +232,7 @@ contract CircuitBreaker is ICircuitBreaker {
         return block.timestamp <= gracePeriodEndTimestamp;
     }
 
-    function setGracePeriod(uint256 _gracePeriodEndTimestamp) external onlyAdmin {}
+    function startGracePeriod(uint256 _gracePeriodEndTimestamp) external onlyAdmin {}
 
     function _onTokenOutflow(
         address _token,

--- a/src/core/CircuitBreaker.sol
+++ b/src/core/CircuitBreaker.sol
@@ -34,6 +34,9 @@ contract CircuitBreaker is ICircuitBreaker {
 
     uint256 public gracePeriodEndTimestamp;
 
+    // Using address(1) as a proxy for native token (ETH, BNB, etc), address(0) could be problematic
+    address public immutable NATIVE_ADDRESS_PROXY = address(1);
+
     uint256 public immutable WITHDRAWAL_PERIOD;
 
     uint256 public immutable TICK_LENGTH;
@@ -64,6 +67,7 @@ contract CircuitBreaker is ICircuitBreaker {
     error RateLimited();
     error NotRateLimited();
     error CooldownPeriodNotReached();
+    error NativeTransferFailed();
 
     ////////////////////////////////////////////////////////////////
     //                         MODIFIERS                          //
@@ -126,9 +130,7 @@ contract CircuitBreaker is ICircuitBreaker {
      * @dev Give protected contracts one function to call for convenience
      */
     function inflowHook(address _token, uint256 _amount) external onlyProtected {
-        /// @dev uint256 could overflow into negative
-        tokenLimiters[_token].recordChange(int256(_amount), WITHDRAWAL_PERIOD, TICK_LENGTH);
-        emit TokenInflow(_token, _amount);
+        _inflowHook(_token, _amount);
     }
 
     function outflowHook(
@@ -137,57 +139,35 @@ contract CircuitBreaker is ICircuitBreaker {
         address _recipient,
         bool _revertOnRateLimit
     ) external onlyProtected {
-        Limiter storage limiter = tokenLimiters[_token];
-        // Check if the token has enforced rate limited
-        if (!limiter.initialized()) {
-            // if it is not rate limited, just transfer the tokens
-            IERC20(_token).safeTransfer(_recipient, _amount);
-            return;
-        }
-        limiter.recordChange(-int256(_amount), WITHDRAWAL_PERIOD, TICK_LENGTH);
-        // Check if currently rate limited, if so, add to locked funds claimable when resolved
-        if (isRateLimited) {
-            if (_revertOnRateLimit) {
-                revert RateLimited();
-            }
-            lockedFunds[_recipient][_token] += _amount;
-            return;
-        }
+        _outflowHook(_token, _amount, _recipient, _revertOnRateLimit);
+    }
 
-        // Check if rate limit is breeched after withdrawal and not in grace period
-        // (grace period allows for withdrawals to be made if rate limit is breeched but overriden)
-        if (limiter.status() == LimitStatus.Breeched && !isInGracePeriod()) {
-            if (_revertOnRateLimit) {
-                revert RateLimited();
-            }
-            // if it is, set rate limited to true
-            isRateLimited = true;
-            lastRateLimitTimestamp = block.timestamp;
-            // add to locked funds claimable when resolved
-            lockedFunds[_recipient][_token] += _amount;
+    function inflowHookNative(uint256 _amount) external onlyProtected {
+        _inflowHook(NATIVE_ADDRESS_PROXY, _amount);
+    }
 
-            emit TokenRateLimitBreached(_token, block.timestamp);
-
-            return;
-        }
-
-        // if everything is good, transfer the tokens
-        IERC20(_token).safeTransfer(_recipient, _amount);
-
-        emit TokenWithdraw(_token, _recipient, _amount);
+    function outflowHookNative(
+        address _recipient,
+        bool _revertOnRateLimit
+    ) external payable onlyProtected {
+        _outflowHook(NATIVE_ADDRESS_PROXY, msg.value, _recipient, _revertOnRateLimit);
     }
 
     /**
      * @notice Allow users to claim locked funds when rate limit is resolved
+     * use address(1) for native token claims
      */
+
     function claimLockedFunds(address _token, address _recipient) external {
         if (lockedFunds[_recipient][_token] == 0) revert NoLockedFunds();
         if (isRateLimited) revert RateLimited();
-        IERC20 erc20Token = IERC20(_token);
-        erc20Token.safeTransfer(_recipient, lockedFunds[_recipient][_token]);
+
+        uint256 amount = lockedFunds[_recipient][_token];
         lockedFunds[_recipient][_token] = 0;
 
         emit LockedFundsClaimed(_token, _recipient);
+
+        _safeTransferIncludingNative(_token, _recipient, amount);
     }
 
     /**
@@ -253,4 +233,69 @@ contract CircuitBreaker is ICircuitBreaker {
     }
 
     function setGracePeriod(uint256 _gracePeriodEndTimestamp) external onlyAdmin {}
+
+    function _outflowHook(
+        address _token,
+        uint256 _amount,
+        address _recipient,
+        bool _revertOnRateLimit
+    ) internal {
+        Limiter storage limiter = tokenLimiters[_token];
+        // Check if the token has enforced rate limited
+        if (!limiter.initialized()) {
+            // if it is not rate limited, just transfer the tokens
+            _safeTransferIncludingNative(_token, _recipient, _amount);
+            return;
+        }
+        limiter.recordChange(-int256(_amount), WITHDRAWAL_PERIOD, TICK_LENGTH);
+        // Check if currently rate limited, if so, add to locked funds claimable when resolved
+        if (isRateLimited) {
+            if (_revertOnRateLimit) {
+                revert RateLimited();
+            }
+            lockedFunds[_recipient][_token] += _amount;
+            return;
+        }
+
+        // Check if rate limit is breeched after withdrawal and not in grace period
+        // (grace period allows for withdrawals to be made if rate limit is breeched but overriden)
+        if (limiter.status() == LimitStatus.Breeched && !isInGracePeriod()) {
+            if (_revertOnRateLimit) {
+                revert RateLimited();
+            }
+            // if it is, set rate limited to true
+            isRateLimited = true;
+            lastRateLimitTimestamp = block.timestamp;
+            // add to locked funds claimable when resolved
+            lockedFunds[_recipient][_token] += _amount;
+
+            emit TokenRateLimitBreached(_token, block.timestamp);
+
+            return;
+        }
+
+        // if everything is good, transfer the tokens
+        _safeTransferIncludingNative(_token, _recipient, _amount);
+
+        emit TokenWithdraw(_token, _recipient, _amount);
+    }
+
+    function _inflowHook(address _token, uint256 _amount) internal {
+        /// @dev uint256 could overflow into negative
+        tokenLimiters[_token].recordChange(int256(_amount), WITHDRAWAL_PERIOD, TICK_LENGTH);
+        emit TokenInflow(_token, _amount);
+    }
+
+    function _safeTransferIncludingNative(
+        address _token,
+        address _recipient,
+        uint256 _amount
+    ) internal {
+        if (_token == NATIVE_ADDRESS_PROXY) {
+            (bool success, ) = _recipient.call{value: _amount}("");
+            if (!success) revert NativeTransferFailed();
+        } else {
+            IERC20(_token).safeTransfer(_recipient, _amount);
+        }
+    }
 }

--- a/src/core/CircuitBreaker.sol
+++ b/src/core/CircuitBreaker.sol
@@ -129,28 +129,28 @@ contract CircuitBreaker is ICircuitBreaker {
     /**
      * @dev Give protected contracts one function to call for convenience
      */
-    function inflowHook(address _token, uint256 _amount) external onlyProtected {
-        _inflowHook(_token, _amount);
+    function onTokenInflow(address _token, uint256 _amount) external onlyProtected {
+        _onTokenInflow(_token, _amount);
     }
 
-    function outflowHook(
+    function onTokenOutflow(
         address _token,
         uint256 _amount,
         address _recipient,
         bool _revertOnRateLimit
     ) external onlyProtected {
-        _outflowHook(_token, _amount, _recipient, _revertOnRateLimit);
+        _onTokenOutflow(_token, _amount, _recipient, _revertOnRateLimit);
     }
 
-    function inflowHookNative(uint256 _amount) external onlyProtected {
-        _inflowHook(NATIVE_ADDRESS_PROXY, _amount);
+    function onTokenInflowNative(uint256 _amount) external onlyProtected {
+        _onTokenInflow(NATIVE_ADDRESS_PROXY, _amount);
     }
 
-    function outflowHookNative(
+    function onTokenOutflowNative(
         address _recipient,
         bool _revertOnRateLimit
     ) external payable onlyProtected {
-        _outflowHook(NATIVE_ADDRESS_PROXY, msg.value, _recipient, _revertOnRateLimit);
+        _onTokenOutflow(NATIVE_ADDRESS_PROXY, msg.value, _recipient, _revertOnRateLimit);
     }
 
     /**
@@ -234,7 +234,7 @@ contract CircuitBreaker is ICircuitBreaker {
 
     function setGracePeriod(uint256 _gracePeriodEndTimestamp) external onlyAdmin {}
 
-    function _outflowHook(
+    function _onTokenOutflow(
         address _token,
         uint256 _amount,
         address _recipient,
@@ -280,7 +280,7 @@ contract CircuitBreaker is ICircuitBreaker {
         emit TokenWithdraw(_token, _recipient, _amount);
     }
 
-    function _inflowHook(address _token, uint256 _amount) internal {
+    function _onTokenInflow(address _token, uint256 _amount) internal {
         /// @dev uint256 could overflow into negative
         tokenLimiters[_token].recordChange(int256(_amount), WITHDRAWAL_PERIOD, TICK_LENGTH);
         emit TokenInflow(_token, _amount);

--- a/src/core/ProtectedContract.sol
+++ b/src/core/ProtectedContract.sol
@@ -19,7 +19,7 @@ contract ProtectedContract {
     }
 
     // Internal function to be used when tokens are deposited
-    // Transfers the tokens from sender to recipient and then calls the circuitBreaker's inflowHook
+    // Transfers the tokens from sender to recipient and then calls the circuitBreaker's onTokenInflow
     function cbInflowSafeTransferFrom(
         address _token,
         address _sender,
@@ -28,12 +28,12 @@ contract ProtectedContract {
     ) internal {
         // Transfer the tokens safely from sender to recipient
         IERC20(_token).safeTransferFrom(_sender, _recipient, _amount);
-        // Call the circuitBreaker's inflowHook
-        circuitBreaker.inflowHook(_token, _amount);
+        // Call the circuitBreaker's onTokenInflow
+        circuitBreaker.onTokenInflow(_token, _amount);
     }
 
     // Internal function to be used when tokens are withdrawn
-    // Transfers the tokens to the circuitBreaker and then calls the circuitBreaker's outflowHook
+    // Transfers the tokens to the circuitBreaker and then calls the circuitBreaker's onTokenOutflow
     function cbOutflowSafeTransfer(
         address _token,
         address _recipient,
@@ -42,13 +42,13 @@ contract ProtectedContract {
     ) internal {
         // Transfer the tokens safely to the circuitBreaker
         IERC20(_token).safeTransfer(address(circuitBreaker), _amount);
-        // Call the circuitBreaker's outflowHook
-        circuitBreaker.outflowHook(_token, _amount, _recipient, _revertOnRateLimit);
+        // Call the circuitBreaker's onTokenOutflow
+        circuitBreaker.onTokenOutflow(_token, _amount, _recipient, _revertOnRateLimit);
     }
 
     function cbInflowNative() internal {
         // Transfer the tokens safely from sender to recipient
-        circuitBreaker.inflowHookNative(msg.value);
+        circuitBreaker.onTokenInflowNative(msg.value);
     }
 
     function cbOutflowNative(
@@ -57,6 +57,6 @@ contract ProtectedContract {
         bool _revertOnRateLimit
     ) internal {
         // Transfer the native tokens safely through the circuitBreaker
-        circuitBreaker.outflowHookNative{value: _amount}(_recipient, _revertOnRateLimit);
+        circuitBreaker.onTokenOutflowNative{value: _amount}(_recipient, _revertOnRateLimit);
     }
 }

--- a/src/core/ProtectedContract.sol
+++ b/src/core/ProtectedContract.sol
@@ -45,4 +45,18 @@ contract ProtectedContract {
         // Call the circuitBreaker's outflowHook
         circuitBreaker.outflowHook(_token, _amount, _recipient, _revertOnRateLimit);
     }
+
+    function cbInflowNative() internal {
+        // Transfer the tokens safely from sender to recipient
+        circuitBreaker.inflowHookNative(msg.value);
+    }
+
+    function cbOutflowNative(
+        address _recipient,
+        uint256 _amount,
+        bool _revertOnRateLimit
+    ) internal {
+        // Transfer the native tokens safely through the circuitBreaker
+        circuitBreaker.outflowHookNative{value: _amount}(_recipient, _revertOnRateLimit);
+    }
 }

--- a/src/interfaces/ICircuitBreaker.sol
+++ b/src/interfaces/ICircuitBreaker.sol
@@ -22,18 +22,18 @@ interface ICircuitBreaker {
         uint256 _minAmountToLimit
     ) external;
 
-    function inflowHook(address _token, uint256 _amount) external;
+    function onTokenInflow(address _token, uint256 _amount) external;
 
-    function outflowHook(
+    function onTokenOutflow(
         address _token,
         uint256 _amount,
         address _recipient,
         bool _revertOnRateLimit
     ) external;
 
-    function inflowHookNative(uint256 _amount) external;
+    function onTokenInflowNative(uint256 _amount) external;
 
-    function outflowHookNative(address _recipient, bool _revertOnRateLimit) external payable;
+    function onTokenOutflowNative(address _recipient, bool _revertOnRateLimit) external payable;
 
     function claimLockedFunds(address _token, address _recipient) external;
 

--- a/src/interfaces/ICircuitBreaker.sol
+++ b/src/interfaces/ICircuitBreaker.sol
@@ -31,6 +31,10 @@ interface ICircuitBreaker {
         bool _revertOnRateLimit
     ) external;
 
+    function inflowHookNative(uint256 _amount) external;
+
+    function outflowHookNative(address _recipient, bool _revertOnRateLimit) external payable;
+
     function claimLockedFunds(address _token, address _recipient) external;
 
     function setAdmin(address _admin) external;

--- a/src/interfaces/ICircuitBreaker.sol
+++ b/src/interfaces/ICircuitBreaker.sol
@@ -47,7 +47,7 @@ interface ICircuitBreaker {
 
     function removeProtectedContracts(address[] calldata _ProtectedContracts) external;
 
-    function setGracePeriod(uint256 _gracePeriodEndTimestamp) external;
+    function startGracePeriod(uint256 _gracePeriodEndTimestamp) external;
 
     /**
      *

--- a/test/mocks/MockDeFiProtocol.sol
+++ b/test/mocks/MockDeFiProtocol.sol
@@ -42,4 +42,12 @@ contract MockDeFiProtocol is ProtectedContract {
 
         // Your logic here
     }
+
+    function depositNative() external payable {
+        cbInflowNative();
+    }
+
+    function withdrawalNative(uint256 _amount) external {
+        cbOutflowNative(msg.sender, _amount, false);
+    }
 }


### PR DESCRIPTION
Most projects will want to protect native ETH as well. Some may already be using WETH in their protocol, but others may not, and the lift from our side is relatively small.

- Adding native eth support for token inflows and outflows
- Reserving 'address(1)' = '0x00..001' for tracking native asset transfers to work with our current implementation 
- Updating interface to support native inflow and outflows explicitly 
- Testing 
- Small readme update for clarity 
