### PR TITLE
Controversial Admin functions & refactoring

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -7,6 +7,10 @@
     "ordering": "warn",
     "no-inline-assembly": "off",
     "not-rely-on-time": "off",
-    "avoid-tx-origin": "off"
+    "avoid-tx-origin": "off",
+    "func-name-mixedcase": "off",
+    "var-name-mixedcase": "off",
+    "private-vars-leading-underscore": "off",
+    "func-param-name-mixedcase": "off"
   }
 }

--- a/src/core/ProtectedContract.sol
+++ b/src/core/ProtectedContract.sol
@@ -20,12 +20,7 @@ contract ProtectedContract {
 
     // Internal function to be used when tokens are deposited
     // Transfers the tokens from sender to recipient and then calls the circuitBreaker's onTokenInflow
-    function cbInflowSafeTransferFrom(
-        address _token,
-        address _sender,
-        address _recipient,
-        uint256 _amount
-    ) internal {
+    function cbInflowSafeTransferFrom(address _token, address _sender, address _recipient, uint256 _amount) internal {
         // Transfer the tokens safely from sender to recipient
         IERC20(_token).safeTransferFrom(_sender, _recipient, _amount);
         // Call the circuitBreaker's onTokenInflow
@@ -34,12 +29,9 @@ contract ProtectedContract {
 
     // Internal function to be used when tokens are withdrawn
     // Transfers the tokens to the circuitBreaker and then calls the circuitBreaker's onTokenOutflow
-    function cbOutflowSafeTransfer(
-        address _token,
-        address _recipient,
-        uint256 _amount,
-        bool _revertOnRateLimit
-    ) internal {
+    function cbOutflowSafeTransfer(address _token, address _recipient, uint256 _amount, bool _revertOnRateLimit)
+        internal
+    {
         // Transfer the tokens safely to the circuitBreaker
         IERC20(_token).safeTransfer(address(circuitBreaker), _amount);
         // Call the circuitBreaker's onTokenOutflow
@@ -51,11 +43,7 @@ contract ProtectedContract {
         circuitBreaker.onTokenInflowNative(msg.value);
     }
 
-    function cbOutflowNative(
-        address _recipient,
-        uint256 _amount,
-        bool _revertOnRateLimit
-    ) internal {
+    function cbOutflowNative(address _recipient, uint256 _amount, bool _revertOnRateLimit) internal {
         // Transfer the native tokens safely through the circuitBreaker
         circuitBreaker.onTokenOutflowNative{value: _amount}(_recipient, _revertOnRateLimit);
     }

--- a/src/interfaces/ICircuitBreaker.sol
+++ b/src/interfaces/ICircuitBreaker.sol
@@ -10,26 +10,9 @@ interface ICircuitBreaker {
      *
      */
 
-    function registerToken(
-        address _token,
-        uint256 _metricThreshold,
-        uint256 _minAmountToLimit
-    ) external;
-
-    function updateTokenParams(
-        address _token,
-        uint256 _metricThreshold,
-        uint256 _minAmountToLimit
-    ) external;
-
     function onTokenInflow(address _token, uint256 _amount) external;
 
-    function onTokenOutflow(
-        address _token,
-        uint256 _amount,
-        address _recipient,
-        bool _revertOnRateLimit
-    ) external;
+    function onTokenOutflow(address _token, uint256 _amount, address _recipient, bool _revertOnRateLimit) external;
 
     function onTokenInflowNative(uint256 _amount) external;
 
@@ -37,17 +20,25 @@ interface ICircuitBreaker {
 
     function claimLockedFunds(address _token, address _recipient) external;
 
-    function setAdmin(address _admin) external;
+    function overrideExpiredRateLimit() external;
+
+    function registerToken(address _token, uint256 _metricThreshold, uint256 _minAmountToLimit) external;
+
+    function updateTokenParams(address _token, uint256 _metricThreshold, uint256 _minAmountToLimit) external;
 
     function overrideRateLimit() external;
-
-    function overrideExpiredRateLimit() external;
 
     function addProtectedContracts(address[] calldata _ProtectedContracts) external;
 
     function removeProtectedContracts(address[] calldata _ProtectedContracts) external;
 
     function startGracePeriod(uint256 _gracePeriodEndTimestamp) external;
+
+    function releaseLockedFunds(address _token, address[] calldata _recipients) external;
+
+    function withdrawHackerFunds(address _token, address _hacker, address _recipient) external;
+
+    function setAdmin(address _admin) external;
 
     /**
      *

--- a/src/interfaces/ICircuitBreaker.sol
+++ b/src/interfaces/ICircuitBreaker.sol
@@ -12,7 +12,12 @@ interface ICircuitBreaker {
 
     function onTokenInflow(address _token, uint256 _amount) external;
 
-    function onTokenOutflow(address _token, uint256 _amount, address _recipient, bool _revertOnRateLimit) external;
+    function onTokenOutflow(
+        address _token,
+        uint256 _amount,
+        address _recipient,
+        bool _revertOnRateLimit
+    ) external;
 
     function onTokenInflowNative(uint256 _amount) external;
 
@@ -22,9 +27,17 @@ interface ICircuitBreaker {
 
     function overrideExpiredRateLimit() external;
 
-    function registerToken(address _token, uint256 _metricThreshold, uint256 _minAmountToLimit) external;
+    function registerToken(
+        address _token,
+        uint256 _metricThreshold,
+        uint256 _minAmountToLimit
+    ) external;
 
-    function updateTokenParams(address _token, uint256 _metricThreshold, uint256 _minAmountToLimit) external;
+    function updateTokenParams(
+        address _token,
+        uint256 _metricThreshold,
+        uint256 _minAmountToLimit
+    ) external;
 
     function overrideRateLimit() external;
 
@@ -34,11 +47,14 @@ interface ICircuitBreaker {
 
     function startGracePeriod(uint256 _gracePeriodEndTimestamp) external;
 
-    function releaseLockedFunds(address _token, address[] calldata _recipients) external;
-
-    function withdrawHackerFunds(address _token, address _hacker, address _recipient) external;
-
     function setAdmin(address _admin) external;
+
+    function markAsExploited() external;
+
+    function migrateFundsAfterExploit(
+        address[] calldata _tokens,
+        address _recipientMultiSig
+    ) external;
 
     /**
      *

--- a/src/utils/LimiterLib.sol
+++ b/src/utils/LimiterLib.sol
@@ -18,11 +18,7 @@ library LimiterLib {
     error LimiterAlreadyInitialized();
     error LimiterNotInitialized();
 
-    function init(
-        Limiter storage limiter,
-        uint256 minLiqRetainedBps,
-        uint256 limitBeginThreshold
-    ) internal {
+    function init(Limiter storage limiter, uint256 minLiqRetainedBps, uint256 limitBeginThreshold) internal {
         if (minLiqRetainedBps == 0 || minLiqRetainedBps > BPS_DENOMINATOR) {
             revert InvalidMinimumLiquidityThreshold();
         }
@@ -31,11 +27,7 @@ library LimiterLib {
         limiter.limitBeginThreshold = limitBeginThreshold;
     }
 
-    function updateParams(
-        Limiter storage limiter,
-        uint256 minLiqRetainedBps,
-        uint256 limitBeginThreshold
-    ) internal {
+    function updateParams(Limiter storage limiter, uint256 minLiqRetainedBps, uint256 limitBeginThreshold) internal {
         if (minLiqRetainedBps == 0 || minLiqRetainedBps > BPS_DENOMINATOR) {
             revert InvalidMinimumLiquidityThreshold();
         }
@@ -44,12 +36,9 @@ library LimiterLib {
         limiter.limitBeginThreshold = limitBeginThreshold;
     }
 
-    function recordChange(
-        Limiter storage limiter,
-        int256 amount,
-        uint256 withdrawalPeriod,
-        uint256 tickLength
-    ) internal {
+    function recordChange(Limiter storage limiter, int256 amount, uint256 withdrawalPeriod, uint256 tickLength)
+        internal
+    {
         // If token does not have a rate limit, do nothing
         if (!initialized(limiter)) {
             return;
@@ -63,10 +52,7 @@ library LimiterLib {
             // if there is no head, set the head to the new inflow
             limiter.listHead = currentTickTimestamp;
             limiter.listTail = currentTickTimestamp;
-            limiter.listNodes[currentTickTimestamp] = LiqChangeNode({
-                amount: amount,
-                nextTimestamp: 0
-            });
+            limiter.listNodes[currentTickTimestamp] = LiqChangeNode({amount: amount, nextTimestamp: 0});
         } else {
             // if there is a head, check if the new inflow is within the period
             // if it is, add it to the head
@@ -83,10 +69,7 @@ library LimiterLib {
             } else {
                 // add to tail
                 limiter.listNodes[listTail].nextTimestamp = currentTickTimestamp;
-                limiter.listNodes[currentTickTimestamp] = LiqChangeNode({
-                    amount: amount,
-                    nextTimestamp: 0
-                });
+                limiter.listNodes[currentTickTimestamp] = LiqChangeNode({amount: amount, nextTimestamp: 0});
                 limiter.listTail = currentTickTimestamp;
             }
         }
@@ -101,11 +84,7 @@ library LimiterLib {
         int256 totalChange = 0;
         uint256 iter = 0;
 
-        while (
-            currentHead != 0 &&
-            block.timestamp - currentHead >= withdrawalPeriod &&
-            iter < totalIters
-        ) {
+        while (currentHead != 0 && block.timestamp - currentHead >= withdrawalPeriod && iter < totalIters) {
             LiqChangeNode storage node = limiter.listNodes[currentHead];
             totalChange += node.amount;
             uint256 nextTimestamp = node.nextTimestamp;

--- a/test/core/admin/CircuitBreakerAdminOps.t.sol
+++ b/test/core/admin/CircuitBreakerAdminOps.t.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import {Test} from "forge-std/Test.sol";
+import {MockToken} from "../../mocks/MockToken.sol";
+import {MockDeFiProtocol} from "../../mocks/MockDeFiProtocol.sol";
+import {CircuitBreaker} from "src/core/CircuitBreaker.sol";
+import {LimiterLib} from "src/utils/LimiterLib.sol";
+
+contract CircuitBreakerAdminOpsTest is Test {
+    MockToken internal token;
+    MockToken internal secondToken;
+    MockToken internal unlimitedToken;
+
+    address internal NATIVE_ADDRESS_PROXY = address(1);
+    CircuitBreaker internal circuitBreaker;
+    MockDeFiProtocol internal deFi;
+
+    address internal alice = vm.addr(0x1);
+    address internal bob = vm.addr(0x2);
+    address internal admin = vm.addr(0x3);
+
+    function setUp() public {
+        token = new MockToken("USDC", "USDC");
+        circuitBreaker = new CircuitBreaker(admin, 3 days, 4 hours, 5 minutes);
+        deFi = new MockDeFiProtocol(address(circuitBreaker));
+
+        address[] memory addresses = new address[](1);
+        addresses[0] = address(deFi);
+
+        vm.prank(admin);
+        circuitBreaker.addProtectedContracts(addresses);
+
+        vm.prank(admin);
+        // Protect USDC with 70% max drawdown per 4 hours
+        circuitBreaker.registerToken(address(token), 7000, 1000e18);
+        vm.prank(admin);
+        circuitBreaker.registerToken(NATIVE_ADDRESS_PROXY, 7000, 1000e18);
+        vm.warp(1 hours);
+    }
+
+    function test_initialization_shouldBeSuccessful() public {
+        CircuitBreaker newCircuitBreaker = new CircuitBreaker(admin, 3 days, 3 hours, 5 minutes);
+        assertEq(newCircuitBreaker.admin(), admin);
+        assertEq(newCircuitBreaker.rateLimitCooldownPeriod(), 3 days);
+    }
+
+    function test_registerToken_whenMinimumLiquidityThresholdIsInvalidShouldFail() public {
+        secondToken = new MockToken("DAI", "DAI");
+        vm.prank(admin);
+        vm.expectRevert(LimiterLib.InvalidMinimumLiquidityThreshold.selector);
+        circuitBreaker.registerToken(address(secondToken), 0, 1000e18);
+
+        vm.prank(admin);
+        vm.expectRevert(LimiterLib.InvalidMinimumLiquidityThreshold.selector);
+        circuitBreaker.registerToken(address(secondToken), 10_001, 1000e18);
+
+        vm.prank(admin);
+        vm.expectRevert(LimiterLib.InvalidMinimumLiquidityThreshold.selector);
+        circuitBreaker.updateTokenParams(address(secondToken), 0, 2000e18);
+
+        vm.prank(admin);
+        vm.expectRevert(LimiterLib.InvalidMinimumLiquidityThreshold.selector);
+        circuitBreaker.updateTokenParams(address(secondToken), 10_001, 2000e18);
+    }
+
+    function test_registerToken_whenAlreadyRegisteredShouldFail() public {
+        secondToken = new MockToken("DAI", "DAI");
+        vm.prank(admin);
+        circuitBreaker.registerToken(address(secondToken), 7000, 1000e18);
+        // Cannot register the same token twice
+        vm.expectRevert(LimiterLib.LimiterAlreadyInitialized.selector);
+        vm.prank(admin);
+        circuitBreaker.registerToken(address(secondToken), 7000, 1000e18);
+    }
+
+    function test_registerToken_shouldBeSuccessful() public {
+        secondToken = new MockToken("DAI", "DAI");
+        vm.prank(admin);
+        circuitBreaker.registerToken(address(secondToken), 7000, 1000e18);
+        (uint256 minLiquidityThreshold, uint256 minAmount,,,,) = circuitBreaker.tokenLimiters(address(secondToken));
+        assertEq(minAmount, 1000e18);
+        assertEq(minLiquidityThreshold, 7000);
+
+        vm.prank(admin);
+        circuitBreaker.updateTokenParams(address(secondToken), 8000, 2000e18);
+        (minLiquidityThreshold, minAmount,,,,) = circuitBreaker.tokenLimiters(address(secondToken));
+        assertEq(minAmount, 2000e18);
+        assertEq(minLiquidityThreshold, 8000);
+    }
+
+    function test_addProtectedContracts_shouldBeSuccessful() public {
+        MockDeFiProtocol secondDeFi = new MockDeFiProtocol(address(circuitBreaker));
+
+        address[] memory addresses = new address[](1);
+        addresses[0] = address(secondDeFi);
+        vm.prank(admin);
+        circuitBreaker.addProtectedContracts(addresses);
+
+        assertEq(circuitBreaker.isProtectedContract(address(secondDeFi)), true);
+    }
+
+    function test_removeProtectedContracts_shouldBeSuccessful() public {
+        MockDeFiProtocol secondDeFi = new MockDeFiProtocol(address(circuitBreaker));
+
+        address[] memory addresses = new address[](1);
+        addresses[0] = address(secondDeFi);
+        vm.prank(admin);
+        circuitBreaker.addProtectedContracts(addresses);
+
+        vm.prank(admin);
+        circuitBreaker.removeProtectedContracts(addresses);
+        assertEq(circuitBreaker.isProtectedContract(address(secondDeFi)), false);
+    }
+
+    function test_setAdmin_WhenCallerIsNotAdminShouldFail() public {
+        vm.expectRevert(CircuitBreaker.NotAdmin.selector);
+        circuitBreaker.setAdmin(alice);
+    }
+
+    function test_setAdmin_shouldBeSuccessful() public {
+        assertEq(circuitBreaker.admin(), admin);
+        vm.prank(admin);
+        circuitBreaker.setAdmin(bob);
+        assertEq(circuitBreaker.admin(), bob);
+
+        vm.expectRevert();
+        vm.prank(admin);
+        circuitBreaker.setAdmin(alice);
+    }
+
+    function test_startGracePeriod_whenCallerIsNotAdminShouldFail() public {
+        vm.expectRevert(CircuitBreaker.NotAdmin.selector);
+        circuitBreaker.startGracePeriod(block.timestamp + 10);
+    }
+
+    function test_startGracePeriod_whenGracePeriodEndIsInThePastShouldFail() public {
+        vm.expectRevert(CircuitBreaker.InvalidGracePeriodEnd.selector);
+        vm.prank(admin);
+        circuitBreaker.startGracePeriod(block.timestamp - 10);
+    }
+
+    function test_startGracePeriod_shouldBeSuccessfull() public {
+        vm.prank(admin);
+        circuitBreaker.startGracePeriod(block.timestamp + 10);
+    }
+}

--- a/test/core/admin/CircuitBreakerAdminOps.t.sol
+++ b/test/core/admin/CircuitBreakerAdminOps.t.sol
@@ -78,13 +78,17 @@ contract CircuitBreakerAdminOpsTest is Test {
         secondToken = new MockToken("DAI", "DAI");
         vm.prank(admin);
         circuitBreaker.registerToken(address(secondToken), 7000, 1000e18);
-        (uint256 minLiquidityThreshold, uint256 minAmount,,,,) = circuitBreaker.tokenLimiters(address(secondToken));
+        (uint256 minLiquidityThreshold, uint256 minAmount, , , , ) = circuitBreaker.tokenLimiters(
+            address(secondToken)
+        );
         assertEq(minAmount, 1000e18);
         assertEq(minLiquidityThreshold, 7000);
 
         vm.prank(admin);
         circuitBreaker.updateTokenParams(address(secondToken), 8000, 2000e18);
-        (minLiquidityThreshold, minAmount,,,,) = circuitBreaker.tokenLimiters(address(secondToken));
+        (minLiquidityThreshold, minAmount, , , , ) = circuitBreaker.tokenLimiters(
+            address(secondToken)
+        );
         assertEq(minAmount, 2000e18);
         assertEq(minLiquidityThreshold, 8000);
     }

--- a/test/core/admin/CircuitBreakerEmergencyOps.t.sol
+++ b/test/core/admin/CircuitBreakerEmergencyOps.t.sol
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import {Test} from "forge-std/Test.sol";
+import {MockToken} from "../../mocks/MockToken.sol";
+import {MockDeFiProtocol} from "../../mocks/MockDeFiProtocol.sol";
+import {CircuitBreaker} from "src/core/CircuitBreaker.sol";
+import {LimiterLib} from "src/utils/LimiterLib.sol";
+
+contract CircuitBreakerEmergencyOpsTest is Test {
+    event FundsReleased(address indexed token);
+    event HackerFundsWithdrawn(address indexed hacker, address indexed token, address indexed receiver, uint256 amount);
+
+    MockToken internal token;
+    MockToken internal secondToken;
+    MockToken internal unlimitedToken;
+
+    address internal NATIVE_ADDRESS_PROXY = address(1);
+    CircuitBreaker internal circuitBreaker;
+    MockDeFiProtocol internal deFi;
+
+    address internal alice = vm.addr(0x1);
+    address internal bob = vm.addr(0x2);
+    address internal admin = vm.addr(0x3);
+
+    function setUp() public {
+        token = new MockToken("USDC", "USDC");
+        circuitBreaker = new CircuitBreaker(admin, 3 days, 4 hours, 5 minutes);
+        deFi = new MockDeFiProtocol(address(circuitBreaker));
+
+        address[] memory addresses = new address[](1);
+        addresses[0] = address(deFi);
+
+        vm.prank(admin);
+        circuitBreaker.addProtectedContracts(addresses);
+
+        vm.prank(admin);
+        // Protect USDC with 70% max drawdown per 4 hours
+        circuitBreaker.registerToken(address(token), 7000, 1000e18);
+        vm.prank(admin);
+        circuitBreaker.registerToken(NATIVE_ADDRESS_PROXY, 7000, 1000e18);
+        vm.warp(1 hours);
+    }
+
+    function test_releaseLockedFunds_ifCallerIsNotAdminShouldFail() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+
+        vm.expectRevert(CircuitBreaker.NotAdmin.selector);
+        circuitBreaker.releaseLockedFunds(address(token), recipients);
+    }
+
+    function test_releaseLockedFunds_ifNotRateLimitedShouldFail() public {
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+
+        vm.prank(admin);
+        vm.expectRevert(CircuitBreaker.NotRateLimited.selector);
+        circuitBreaker.releaseLockedFunds(address(token), recipients);
+    }
+
+    function test_releaseLockedFunds_ifTokenNotRateLimitedShouldFail() public {
+        secondToken = new MockToken("DAI", "DAI");
+        vm.prank(admin);
+        circuitBreaker.registerToken(address(secondToken), 7000, 1000e18);
+
+        token.mint(alice, 1_000_000e18);
+
+        vm.prank(alice);
+        token.approve(address(deFi), 1_000_000e18);
+
+        vm.prank(alice);
+        deFi.deposit(address(token), 1_000_000e18);
+
+        int256 withdrawalAmount = 300_001e18;
+        vm.warp(5 hours);
+        vm.prank(alice);
+        deFi.withdrawal(address(token), uint256(withdrawalAmount));
+        assertEq(circuitBreaker.isRateLimited(), true);
+        assertEq(circuitBreaker.isRateLimitBreeched(address(secondToken)), false);
+
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+
+        vm.prank(admin);
+        vm.expectRevert(CircuitBreaker.TokenNotRateLimited.selector);
+        circuitBreaker.releaseLockedFunds(address(secondToken), recipients);
+    }
+
+    function test_releaseLockedFunds_ifRecipientHasNoLockedFundsShouldFail() public {
+        token.mint(alice, 1_000_000e18);
+
+        vm.prank(alice);
+        token.approve(address(deFi), 1_000_000e18);
+
+        vm.prank(alice);
+        deFi.deposit(address(token), 1_000_000e18);
+
+        int256 withdrawalAmount = 300_001e18;
+        vm.warp(5 hours);
+        vm.prank(alice);
+        deFi.withdrawal(address(token), uint256(withdrawalAmount));
+        assertEq(circuitBreaker.isRateLimited(), true);
+        assertEq(circuitBreaker.isRateLimitBreeched(address(token)), true);
+
+        address[] memory recipients = new address[](1);
+        recipients[0] = bob;
+
+        vm.prank(admin);
+        vm.expectRevert(CircuitBreaker.NoLockedFunds.selector);
+        circuitBreaker.releaseLockedFunds(address(token), recipients);
+    }
+
+    function test_releaseLockedFunds_shouldBeSuccessful() public {
+        token.mint(alice, 1_000_000e18);
+        token.mint(bob, 1_000_000e18);
+
+        vm.prank(alice);
+        token.approve(address(deFi), 1_000_000e18);
+
+        vm.prank(bob);
+        token.approve(address(deFi), 1_000_000e18);
+
+        vm.prank(alice);
+        deFi.deposit(address(token), 1_000_000e18);
+
+        vm.prank(bob);
+        deFi.deposit(address(token), 1_000_000e18);
+
+        int256 withdrawalAmount = 700_000e18;
+
+        vm.warp(5 hours);
+
+        vm.prank(alice);
+        deFi.withdrawal(address(token), uint256(withdrawalAmount));
+
+        assertEq(circuitBreaker.isRateLimited(), true);
+        assertEq(circuitBreaker.isRateLimitBreeched(address(token)), true);
+
+        vm.prank(bob);
+        deFi.withdrawal(address(token), 1_000_000e18);
+
+        address[] memory recipients = new address[](1);
+        recipients[0] = bob;
+
+        vm.prank(admin);
+        vm.expectEmit(true, false, false, false);
+        emit FundsReleased(address(token));
+        circuitBreaker.releaseLockedFunds(address(token), recipients);
+        assertEq(token.balanceOf(bob), 1_000_000e18);
+        assertEq(token.balanceOf(alice), 0);
+        assertEq(token.balanceOf(address(circuitBreaker)), uint256(withdrawalAmount));
+        assertEq(token.balanceOf(address(deFi)), 1_000_000e18 - uint256(withdrawalAmount));
+    }
+
+    function test_withdrawHackerFunds_ifCallerIsNotAdminShouldFail() public {
+        address recipient = makeAddr("hackedFundsRecipient");
+
+        vm.expectRevert(CircuitBreaker.NotAdmin.selector);
+        circuitBreaker.withdrawHackerFunds(address(token), alice, recipient);
+    }
+
+    function test_withdrawHackerFunds_ifRecipientAddressIsInvalidShouldFail() public {
+        vm.prank(admin);
+        vm.expectRevert(CircuitBreaker.InvalidRecipientAddress.selector);
+        circuitBreaker.withdrawHackerFunds(address(token), alice, address(0));
+    }
+
+    function test_withdrawHackerFunds_ifNotRateLimitedShouldFail() public {
+        address recipient = makeAddr("hackedFundsRecipient");
+
+        vm.prank(admin);
+        vm.expectRevert(CircuitBreaker.NotRateLimited.selector);
+        circuitBreaker.withdrawHackerFunds(address(token), alice, recipient);
+    }
+
+    function test_withdrawHackerFunds_ifTokenNotRateLimitedShouldFail() public {
+        secondToken = new MockToken("DAI", "DAI");
+        vm.prank(admin);
+        circuitBreaker.registerToken(address(secondToken), 7000, 1000e18);
+
+        token.mint(alice, 1_000_000e18);
+
+        vm.prank(alice);
+        token.approve(address(deFi), 1_000_000e18);
+
+        vm.prank(alice);
+        deFi.deposit(address(token), 1_000_000e18);
+
+        int256 withdrawalAmount = 300_001e18;
+        vm.warp(5 hours);
+        vm.prank(alice);
+        deFi.withdrawal(address(token), uint256(withdrawalAmount));
+        assertEq(circuitBreaker.isRateLimited(), true);
+        assertEq(circuitBreaker.isRateLimitBreeched(address(secondToken)), false);
+
+        address recipient = makeAddr("hackedFundsRecipient");
+
+        vm.prank(admin);
+        vm.expectRevert(CircuitBreaker.TokenNotRateLimited.selector);
+        circuitBreaker.withdrawHackerFunds(address(secondToken), alice, recipient);
+    }
+
+    function test_withdrawHackerFunds_ifHackerHasNoLockedFundsShouldFail() public {
+        vm.prank(admin);
+        circuitBreaker.registerToken(address(secondToken), 7000, 1000e18);
+
+        token.mint(alice, 1_000_000e18);
+
+        vm.prank(alice);
+        token.approve(address(deFi), 1_000_000e18);
+
+        vm.prank(alice);
+        deFi.deposit(address(token), 1_000_000e18);
+
+        int256 withdrawalAmount = 300_001e18;
+        vm.warp(5 hours);
+        vm.prank(alice);
+        deFi.withdrawal(address(token), uint256(withdrawalAmount));
+        assertEq(circuitBreaker.isRateLimited(), true);
+        assertEq(circuitBreaker.isRateLimitBreeched(address(token)), true);
+
+        address recipient = makeAddr("hackedFundsRecipient");
+
+        vm.prank(admin);
+        vm.expectRevert(CircuitBreaker.NoLockedFunds.selector);
+        circuitBreaker.withdrawHackerFunds(address(token), bob, recipient);
+    }
+
+    function test_withdrawHackerFunds_shouldBeSuccessful() public {
+        token.mint(alice, 1_000_000e18);
+        token.mint(bob, 1_000_000e18);
+
+        vm.prank(alice);
+        token.approve(address(deFi), 1_000_000e18);
+
+        vm.prank(bob);
+        token.approve(address(deFi), 1_000_000e18);
+
+        vm.prank(alice);
+        deFi.deposit(address(token), 1_000_000e18);
+
+        vm.prank(bob);
+        deFi.deposit(address(token), 1_000_000e18);
+
+        int256 withdrawalAmount1 = 599_999e18;
+        int256 withdrawalAmount2 = 150_000e18;
+
+        vm.warp(5 hours);
+
+        vm.startPrank(alice);
+
+        deFi.withdrawal(address(token), uint256(withdrawalAmount1));
+
+        deFi.withdrawal(address(token), uint256(withdrawalAmount2));
+
+        vm.stopPrank();
+        assertEq(circuitBreaker.isRateLimited(), true);
+        assertEq(circuitBreaker.isRateLimitBreeched(address(token)), true);
+
+        vm.prank(bob);
+        deFi.withdrawal(address(token), 1_000_000e18);
+
+        address recipient = makeAddr("hackedFundsRecipient");
+
+        vm.prank(admin);
+        vm.expectEmit(true, true, true, true);
+        emit HackerFundsWithdrawn(alice, address(token), recipient, uint256(withdrawalAmount2));
+        circuitBreaker.withdrawHackerFunds(address(token), alice, recipient);
+        assertEq(token.balanceOf(bob), 0);
+        assertEq(token.balanceOf(alice), uint256(withdrawalAmount1));
+        assertEq(token.balanceOf(address(circuitBreaker)), 1_000_000e18);
+        assertEq(token.balanceOf(address(deFi)), 1_000_000e18 - uint256(withdrawalAmount1) - uint256(withdrawalAmount2));
+        assertEq(token.balanceOf(recipient), uint256(withdrawalAmount2));
+    }
+}

--- a/test/core/admin/CircuitBreakerEmergencyOps.t.sol
+++ b/test/core/admin/CircuitBreakerEmergencyOps.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.19;
 
+import "forge-std/console.sol";
 import {Test} from "forge-std/Test.sol";
 import {MockToken} from "../../mocks/MockToken.sol";
 import {MockDeFiProtocol} from "../../mocks/MockDeFiProtocol.sol";
@@ -9,7 +10,12 @@ import {LimiterLib} from "src/utils/LimiterLib.sol";
 
 contract CircuitBreakerEmergencyOpsTest is Test {
     event FundsReleased(address indexed token);
-    event HackerFundsWithdrawn(address indexed hacker, address indexed token, address indexed receiver, uint256 amount);
+    event HackerFundsWithdrawn(
+        address indexed hacker,
+        address indexed token,
+        address indexed receiver,
+        uint256 amount
+    );
 
     MockToken internal token;
     MockToken internal secondToken;
@@ -42,24 +48,20 @@ contract CircuitBreakerEmergencyOpsTest is Test {
         vm.warp(1 hours);
     }
 
-    function test_releaseLockedFunds_ifCallerIsNotAdminShouldFail() public {
-        address[] memory recipients = new address[](1);
-        recipients[0] = alice;
-
+    function test_markAsExploited_ifCallerIsNotAdminShouldFail() public {
         vm.expectRevert(CircuitBreaker.NotAdmin.selector);
-        circuitBreaker.releaseLockedFunds(address(token), recipients);
+        circuitBreaker.markAsExploited();
     }
 
-    function test_releaseLockedFunds_ifNotRateLimitedShouldFail() public {
-        address[] memory recipients = new address[](1);
-        recipients[0] = alice;
-
+    function test_migrateFundsAfterExploit_ifNotExploitedShouldFail() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(token);
         vm.prank(admin);
-        vm.expectRevert(CircuitBreaker.NotRateLimited.selector);
-        circuitBreaker.releaseLockedFunds(address(token), recipients);
+        vm.expectRevert(CircuitBreaker.NotExploited.selector);
+        circuitBreaker.migrateFundsAfterExploit(tokens, address(admin));
     }
 
-    function test_releaseLockedFunds_ifTokenNotRateLimitedShouldFail() public {
+    function test_ifTokenNotRateLimitedShouldFail() public {
         secondToken = new MockToken("DAI", "DAI");
         vm.prank(admin);
         circuitBreaker.registerToken(address(secondToken), 7000, 1000e18);
@@ -78,16 +80,9 @@ contract CircuitBreakerEmergencyOpsTest is Test {
         deFi.withdrawal(address(token), uint256(withdrawalAmount));
         assertEq(circuitBreaker.isRateLimited(), true);
         assertEq(circuitBreaker.isRateLimitBreeched(address(secondToken)), false);
-
-        address[] memory recipients = new address[](1);
-        recipients[0] = alice;
-
-        vm.prank(admin);
-        vm.expectRevert(CircuitBreaker.TokenNotRateLimited.selector);
-        circuitBreaker.releaseLockedFunds(address(secondToken), recipients);
     }
 
-    function test_releaseLockedFunds_ifRecipientHasNoLockedFundsShouldFail() public {
+    function test_claimLockedFunds_ifRecipientHasNoLockedFundsShouldFail() public {
         token.mint(alice, 1_000_000e18);
 
         vm.prank(alice);
@@ -103,15 +98,14 @@ contract CircuitBreakerEmergencyOpsTest is Test {
         assertEq(circuitBreaker.isRateLimited(), true);
         assertEq(circuitBreaker.isRateLimitBreeched(address(token)), true);
 
-        address[] memory recipients = new address[](1);
-        recipients[0] = bob;
-
         vm.prank(admin);
         vm.expectRevert(CircuitBreaker.NoLockedFunds.selector);
-        circuitBreaker.releaseLockedFunds(address(token), recipients);
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(token);
+        circuitBreaker.claimLockedFunds(address(token), bob);
     }
 
-    function test_releaseLockedFunds_shouldBeSuccessful() public {
+    function test_claimLockedFunds_shouldBeSuccessful() public {
         token.mint(alice, 1_000_000e18);
         token.mint(bob, 1_000_000e18);
 
@@ -144,41 +138,16 @@ contract CircuitBreakerEmergencyOpsTest is Test {
         recipients[0] = bob;
 
         vm.prank(admin);
-        vm.expectEmit(true, false, false, false);
-        emit FundsReleased(address(token));
-        circuitBreaker.releaseLockedFunds(address(token), recipients);
+        circuitBreaker.overrideRateLimit();
+        vm.prank(bob);
+        circuitBreaker.claimLockedFunds(address(token), bob);
         assertEq(token.balanceOf(bob), 1_000_000e18);
         assertEq(token.balanceOf(alice), 0);
         assertEq(token.balanceOf(address(circuitBreaker)), uint256(withdrawalAmount));
         assertEq(token.balanceOf(address(deFi)), 1_000_000e18 - uint256(withdrawalAmount));
     }
 
-    function test_withdrawHackerFunds_ifCallerIsNotAdminShouldFail() public {
-        address recipient = makeAddr("hackedFundsRecipient");
-
-        vm.expectRevert(CircuitBreaker.NotAdmin.selector);
-        circuitBreaker.withdrawHackerFunds(address(token), alice, recipient);
-    }
-
-    function test_withdrawHackerFunds_ifRecipientAddressIsInvalidShouldFail() public {
-        vm.prank(admin);
-        vm.expectRevert(CircuitBreaker.InvalidRecipientAddress.selector);
-        circuitBreaker.withdrawHackerFunds(address(token), alice, address(0));
-    }
-
-    function test_withdrawHackerFunds_ifNotRateLimitedShouldFail() public {
-        address recipient = makeAddr("hackedFundsRecipient");
-
-        vm.prank(admin);
-        vm.expectRevert(CircuitBreaker.NotRateLimited.selector);
-        circuitBreaker.withdrawHackerFunds(address(token), alice, recipient);
-    }
-
-    function test_withdrawHackerFunds_ifTokenNotRateLimitedShouldFail() public {
-        secondToken = new MockToken("DAI", "DAI");
-        vm.prank(admin);
-        circuitBreaker.registerToken(address(secondToken), 7000, 1000e18);
-
+    function test_reverts_ifIsExploitedFlagUp() public {
         token.mint(alice, 1_000_000e18);
 
         vm.prank(alice);
@@ -191,86 +160,39 @@ contract CircuitBreakerEmergencyOpsTest is Test {
         vm.warp(5 hours);
         vm.prank(alice);
         deFi.withdrawal(address(token), uint256(withdrawalAmount));
+
         assertEq(circuitBreaker.isRateLimited(), true);
-        assertEq(circuitBreaker.isRateLimitBreeched(address(secondToken)), false);
 
-        address recipient = makeAddr("hackedFundsRecipient");
-
+        // Exploit
         vm.prank(admin);
-        vm.expectRevert(CircuitBreaker.TokenNotRateLimited.selector);
-        circuitBreaker.withdrawHackerFunds(address(secondToken), alice, recipient);
-    }
-
-    function test_withdrawHackerFunds_ifHackerHasNoLockedFundsShouldFail() public {
-        vm.prank(admin);
-        circuitBreaker.registerToken(address(secondToken), 7000, 1000e18);
+        circuitBreaker.markAsExploited();
 
         token.mint(alice, 1_000_000e18);
-
         vm.prank(alice);
         token.approve(address(deFi), 1_000_000e18);
 
+        vm.expectRevert(CircuitBreaker.ProtocolWasExploited.selector);
         vm.prank(alice);
         deFi.deposit(address(token), 1_000_000e18);
 
-        int256 withdrawalAmount = 300_001e18;
-        vm.warp(5 hours);
+        vm.expectRevert(CircuitBreaker.ProtocolWasExploited.selector);
         vm.prank(alice);
         deFi.withdrawal(address(token), uint256(withdrawalAmount));
-        assertEq(circuitBreaker.isRateLimited(), true);
-        assertEq(circuitBreaker.isRateLimitBreeched(address(token)), true);
 
-        address recipient = makeAddr("hackedFundsRecipient");
-
-        vm.prank(admin);
-        vm.expectRevert(CircuitBreaker.NoLockedFunds.selector);
-        circuitBreaker.withdrawHackerFunds(address(token), bob, recipient);
-    }
-
-    function test_withdrawHackerFunds_shouldBeSuccessful() public {
-        token.mint(alice, 1_000_000e18);
-        token.mint(bob, 1_000_000e18);
-
+        vm.expectRevert(CircuitBreaker.ProtocolWasExploited.selector);
         vm.prank(alice);
-        token.approve(address(deFi), 1_000_000e18);
+        circuitBreaker.claimLockedFunds(address(token), address(alice));
 
-        vm.prank(bob);
-        token.approve(address(deFi), 1_000_000e18);
-
+        vm.deal(alice, 1_000_000e18);
+        vm.expectRevert(CircuitBreaker.ProtocolWasExploited.selector);
         vm.prank(alice);
-        deFi.deposit(address(token), 1_000_000e18);
+        deFi.depositNative{value: 1_000_000e18}();
 
-        vm.prank(bob);
-        deFi.deposit(address(token), 1_000_000e18);
-
-        int256 withdrawalAmount1 = 599_999e18;
-        int256 withdrawalAmount2 = 150_000e18;
-
-        vm.warp(5 hours);
-
-        vm.startPrank(alice);
-
-        deFi.withdrawal(address(token), uint256(withdrawalAmount1));
-
-        deFi.withdrawal(address(token), uint256(withdrawalAmount2));
-
-        vm.stopPrank();
-        assertEq(circuitBreaker.isRateLimited(), true);
-        assertEq(circuitBreaker.isRateLimitBreeched(address(token)), true);
-
-        vm.prank(bob);
-        deFi.withdrawal(address(token), 1_000_000e18);
-
-        address recipient = makeAddr("hackedFundsRecipient");
-
+        // There are currently 300_001e18 tokens in the contract in the the withdrawable state
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(token);
         vm.prank(admin);
-        vm.expectEmit(true, true, true, true);
-        emit HackerFundsWithdrawn(alice, address(token), recipient, uint256(withdrawalAmount2));
-        circuitBreaker.withdrawHackerFunds(address(token), alice, recipient);
-        assertEq(token.balanceOf(bob), 0);
-        assertEq(token.balanceOf(alice), uint256(withdrawalAmount1));
-        assertEq(token.balanceOf(address(circuitBreaker)), 1_000_000e18);
-        assertEq(token.balanceOf(address(deFi)), 1_000_000e18 - uint256(withdrawalAmount1) - uint256(withdrawalAmount2));
-        assertEq(token.balanceOf(recipient), uint256(withdrawalAmount2));
+        circuitBreaker.migrateFundsAfterExploit(tokens, address(bob));
+        assertEq(token.balanceOf(address(bob)), uint256(withdrawalAmount));
     }
 }


### PR DESCRIPTION
This PR contains the following:
- Admin functions `releaseLockedFunds` and `withdrawHackerFunds` functions added to the CircuitBreaker contract
- Added implementation for the `startGracePeriod` function at the CircuitBreaker contract
- Added tests and refactored tests
- CircuitBreaker function order changes

Details:
`releaseLockedFunds` - function added for the case when a hack occurs and majority of user funds (panic withdraws) are stuck in the CircuitBreaker contract. Admin should be able to unlock and release the non-hacker funds.

`withdrawHackerFunds` - function added for the case when a hack occurs and an identified hacker has funds stuck in the withdrawal queue (they've already drained the contract until the threshold but the rest of the hacked funds are stuck in the rate limit period). Admin should be able to withdraw funds to an adhoc receiver address, so the hacker is not able to withdraw the stuck funds. 
