### PR TITLE
Updating post exploit logic

### DIFF
--- a/src/interfaces/ICircuitBreaker.sol
+++ b/src/interfaces/ICircuitBreaker.sol
@@ -12,7 +12,12 @@ interface ICircuitBreaker {
 
     function onTokenInflow(address _token, uint256 _amount) external;
 
-    function onTokenOutflow(address _token, uint256 _amount, address _recipient, bool _revertOnRateLimit) external;
+    function onTokenOutflow(
+        address _token,
+        uint256 _amount,
+        address _recipient,
+        bool _revertOnRateLimit
+    ) external;
 
     function onTokenInflowNative(uint256 _amount) external;
 
@@ -22,9 +27,17 @@ interface ICircuitBreaker {
 
     function overrideExpiredRateLimit() external;
 
-    function registerToken(address _token, uint256 _metricThreshold, uint256 _minAmountToLimit) external;
+    function registerToken(
+        address _token,
+        uint256 _metricThreshold,
+        uint256 _minAmountToLimit
+    ) external;
 
-    function updateTokenParams(address _token, uint256 _metricThreshold, uint256 _minAmountToLimit) external;
+    function updateTokenParams(
+        address _token,
+        uint256 _metricThreshold,
+        uint256 _minAmountToLimit
+    ) external;
 
     function overrideRateLimit() external;
 
@@ -34,11 +47,14 @@ interface ICircuitBreaker {
 
     function startGracePeriod(uint256 _gracePeriodEndTimestamp) external;
 
-    function releaseLockedFunds(address _token, address[] calldata _recipients) external;
-
-    function withdrawHackerFunds(address _token, address _hacker, address _recipient) external;
-
     function setAdmin(address _admin) external;
+
+    function markAsExploited() external;
+
+    function migrateFundsAfterExploit(
+        address[] calldata _tokens,
+        address _recipientMultiSig
+    ) external;
 
     /**
      *

--- a/test/core/admin/CircuitBreakerAdminOps.t.sol
+++ b/test/core/admin/CircuitBreakerAdminOps.t.sol
@@ -78,13 +78,17 @@ contract CircuitBreakerAdminOpsTest is Test {
         secondToken = new MockToken("DAI", "DAI");
         vm.prank(admin);
         circuitBreaker.registerToken(address(secondToken), 7000, 1000e18);
-        (uint256 minLiquidityThreshold, uint256 minAmount,,,,) = circuitBreaker.tokenLimiters(address(secondToken));
+        (uint256 minLiquidityThreshold, uint256 minAmount, , , , ) = circuitBreaker.tokenLimiters(
+            address(secondToken)
+        );
         assertEq(minAmount, 1000e18);
         assertEq(minLiquidityThreshold, 7000);
 
         vm.prank(admin);
         circuitBreaker.updateTokenParams(address(secondToken), 8000, 2000e18);
-        (minLiquidityThreshold, minAmount,,,,) = circuitBreaker.tokenLimiters(address(secondToken));
+        (minLiquidityThreshold, minAmount, , , , ) = circuitBreaker.tokenLimiters(
+            address(secondToken)
+        );
         assertEq(minAmount, 2000e18);
         assertEq(minLiquidityThreshold, 8000);
     }

--- a/test/core/admin/CircuitBreakerEmergencyOps.t.sol
+++ b/test/core/admin/CircuitBreakerEmergencyOps.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.19;
 
+import "forge-std/console.sol";
 import {Test} from "forge-std/Test.sol";
 import {MockToken} from "../../mocks/MockToken.sol";
 import {MockDeFiProtocol} from "../../mocks/MockDeFiProtocol.sol";
@@ -9,7 +10,12 @@ import {LimiterLib} from "src/utils/LimiterLib.sol";
 
 contract CircuitBreakerEmergencyOpsTest is Test {
     event FundsReleased(address indexed token);
-    event HackerFundsWithdrawn(address indexed hacker, address indexed token, address indexed receiver, uint256 amount);
+    event HackerFundsWithdrawn(
+        address indexed hacker,
+        address indexed token,
+        address indexed receiver,
+        uint256 amount
+    );
 
     MockToken internal token;
     MockToken internal secondToken;
@@ -42,24 +48,20 @@ contract CircuitBreakerEmergencyOpsTest is Test {
         vm.warp(1 hours);
     }
 
-    function test_releaseLockedFunds_ifCallerIsNotAdminShouldFail() public {
-        address[] memory recipients = new address[](1);
-        recipients[0] = alice;
-
+    function test_markAsExploited_ifCallerIsNotAdminShouldFail() public {
         vm.expectRevert(CircuitBreaker.NotAdmin.selector);
-        circuitBreaker.releaseLockedFunds(address(token), recipients);
+        circuitBreaker.markAsExploited();
     }
 
-    function test_releaseLockedFunds_ifNotRateLimitedShouldFail() public {
-        address[] memory recipients = new address[](1);
-        recipients[0] = alice;
-
+    function test_migrateFundsAfterExploit_ifNotExploitedShouldFail() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(token);
         vm.prank(admin);
-        vm.expectRevert(CircuitBreaker.NotRateLimited.selector);
-        circuitBreaker.releaseLockedFunds(address(token), recipients);
+        vm.expectRevert(CircuitBreaker.NotExploited.selector);
+        circuitBreaker.migrateFundsAfterExploit(tokens, address(admin));
     }
 
-    function test_releaseLockedFunds_ifTokenNotRateLimitedShouldFail() public {
+    function test_ifTokenNotRateLimitedShouldFail() public {
         secondToken = new MockToken("DAI", "DAI");
         vm.prank(admin);
         circuitBreaker.registerToken(address(secondToken), 7000, 1000e18);
@@ -78,16 +80,9 @@ contract CircuitBreakerEmergencyOpsTest is Test {
         deFi.withdrawal(address(token), uint256(withdrawalAmount));
         assertEq(circuitBreaker.isRateLimited(), true);
         assertEq(circuitBreaker.isRateLimitBreeched(address(secondToken)), false);
-
-        address[] memory recipients = new address[](1);
-        recipients[0] = alice;
-
-        vm.prank(admin);
-        vm.expectRevert(CircuitBreaker.TokenNotRateLimited.selector);
-        circuitBreaker.releaseLockedFunds(address(secondToken), recipients);
     }
 
-    function test_releaseLockedFunds_ifRecipientHasNoLockedFundsShouldFail() public {
+    function test_claimLockedFunds_ifRecipientHasNoLockedFundsShouldFail() public {
         token.mint(alice, 1_000_000e18);
 
         vm.prank(alice);
@@ -103,15 +98,14 @@ contract CircuitBreakerEmergencyOpsTest is Test {
         assertEq(circuitBreaker.isRateLimited(), true);
         assertEq(circuitBreaker.isRateLimitBreeched(address(token)), true);
 
-        address[] memory recipients = new address[](1);
-        recipients[0] = bob;
-
         vm.prank(admin);
         vm.expectRevert(CircuitBreaker.NoLockedFunds.selector);
-        circuitBreaker.releaseLockedFunds(address(token), recipients);
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(token);
+        circuitBreaker.claimLockedFunds(address(token), bob);
     }
 
-    function test_releaseLockedFunds_shouldBeSuccessful() public {
+    function test_claimLockedFunds_shouldBeSuccessful() public {
         token.mint(alice, 1_000_000e18);
         token.mint(bob, 1_000_000e18);
 
@@ -144,41 +138,16 @@ contract CircuitBreakerEmergencyOpsTest is Test {
         recipients[0] = bob;
 
         vm.prank(admin);
-        vm.expectEmit(true, false, false, false);
-        emit FundsReleased(address(token));
-        circuitBreaker.releaseLockedFunds(address(token), recipients);
+        circuitBreaker.overrideRateLimit();
+        vm.prank(bob);
+        circuitBreaker.claimLockedFunds(address(token), bob);
         assertEq(token.balanceOf(bob), 1_000_000e18);
         assertEq(token.balanceOf(alice), 0);
         assertEq(token.balanceOf(address(circuitBreaker)), uint256(withdrawalAmount));
         assertEq(token.balanceOf(address(deFi)), 1_000_000e18 - uint256(withdrawalAmount));
     }
 
-    function test_withdrawHackerFunds_ifCallerIsNotAdminShouldFail() public {
-        address recipient = makeAddr("hackedFundsRecipient");
-
-        vm.expectRevert(CircuitBreaker.NotAdmin.selector);
-        circuitBreaker.withdrawHackerFunds(address(token), alice, recipient);
-    }
-
-    function test_withdrawHackerFunds_ifRecipientAddressIsInvalidShouldFail() public {
-        vm.prank(admin);
-        vm.expectRevert(CircuitBreaker.InvalidRecipientAddress.selector);
-        circuitBreaker.withdrawHackerFunds(address(token), alice, address(0));
-    }
-
-    function test_withdrawHackerFunds_ifNotRateLimitedShouldFail() public {
-        address recipient = makeAddr("hackedFundsRecipient");
-
-        vm.prank(admin);
-        vm.expectRevert(CircuitBreaker.NotRateLimited.selector);
-        circuitBreaker.withdrawHackerFunds(address(token), alice, recipient);
-    }
-
-    function test_withdrawHackerFunds_ifTokenNotRateLimitedShouldFail() public {
-        secondToken = new MockToken("DAI", "DAI");
-        vm.prank(admin);
-        circuitBreaker.registerToken(address(secondToken), 7000, 1000e18);
-
+    function test_reverts_ifIsExploitedFlagUp() public {
         token.mint(alice, 1_000_000e18);
 
         vm.prank(alice);
@@ -191,86 +160,39 @@ contract CircuitBreakerEmergencyOpsTest is Test {
         vm.warp(5 hours);
         vm.prank(alice);
         deFi.withdrawal(address(token), uint256(withdrawalAmount));
+
         assertEq(circuitBreaker.isRateLimited(), true);
-        assertEq(circuitBreaker.isRateLimitBreeched(address(secondToken)), false);
 
-        address recipient = makeAddr("hackedFundsRecipient");
-
+        // Exploit
         vm.prank(admin);
-        vm.expectRevert(CircuitBreaker.TokenNotRateLimited.selector);
-        circuitBreaker.withdrawHackerFunds(address(secondToken), alice, recipient);
-    }
-
-    function test_withdrawHackerFunds_ifHackerHasNoLockedFundsShouldFail() public {
-        vm.prank(admin);
-        circuitBreaker.registerToken(address(secondToken), 7000, 1000e18);
+        circuitBreaker.markAsExploited();
 
         token.mint(alice, 1_000_000e18);
-
         vm.prank(alice);
         token.approve(address(deFi), 1_000_000e18);
 
+        vm.expectRevert(CircuitBreaker.ProtocolWasExploited.selector);
         vm.prank(alice);
         deFi.deposit(address(token), 1_000_000e18);
 
-        int256 withdrawalAmount = 300_001e18;
-        vm.warp(5 hours);
+        vm.expectRevert(CircuitBreaker.ProtocolWasExploited.selector);
         vm.prank(alice);
         deFi.withdrawal(address(token), uint256(withdrawalAmount));
-        assertEq(circuitBreaker.isRateLimited(), true);
-        assertEq(circuitBreaker.isRateLimitBreeched(address(token)), true);
 
-        address recipient = makeAddr("hackedFundsRecipient");
-
-        vm.prank(admin);
-        vm.expectRevert(CircuitBreaker.NoLockedFunds.selector);
-        circuitBreaker.withdrawHackerFunds(address(token), bob, recipient);
-    }
-
-    function test_withdrawHackerFunds_shouldBeSuccessful() public {
-        token.mint(alice, 1_000_000e18);
-        token.mint(bob, 1_000_000e18);
-
+        vm.expectRevert(CircuitBreaker.ProtocolWasExploited.selector);
         vm.prank(alice);
-        token.approve(address(deFi), 1_000_000e18);
+        circuitBreaker.claimLockedFunds(address(token), address(alice));
 
-        vm.prank(bob);
-        token.approve(address(deFi), 1_000_000e18);
-
+        vm.deal(alice, 1_000_000e18);
+        vm.expectRevert(CircuitBreaker.ProtocolWasExploited.selector);
         vm.prank(alice);
-        deFi.deposit(address(token), 1_000_000e18);
+        deFi.depositNative{value: 1_000_000e18}();
 
-        vm.prank(bob);
-        deFi.deposit(address(token), 1_000_000e18);
-
-        int256 withdrawalAmount1 = 599_999e18;
-        int256 withdrawalAmount2 = 150_000e18;
-
-        vm.warp(5 hours);
-
-        vm.startPrank(alice);
-
-        deFi.withdrawal(address(token), uint256(withdrawalAmount1));
-
-        deFi.withdrawal(address(token), uint256(withdrawalAmount2));
-
-        vm.stopPrank();
-        assertEq(circuitBreaker.isRateLimited(), true);
-        assertEq(circuitBreaker.isRateLimitBreeched(address(token)), true);
-
-        vm.prank(bob);
-        deFi.withdrawal(address(token), 1_000_000e18);
-
-        address recipient = makeAddr("hackedFundsRecipient");
-
+        // There are currently 300_001e18 tokens in the contract in the the withdrawable state
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(token);
         vm.prank(admin);
-        vm.expectEmit(true, true, true, true);
-        emit HackerFundsWithdrawn(alice, address(token), recipient, uint256(withdrawalAmount2));
-        circuitBreaker.withdrawHackerFunds(address(token), alice, recipient);
-        assertEq(token.balanceOf(bob), 0);
-        assertEq(token.balanceOf(alice), uint256(withdrawalAmount1));
-        assertEq(token.balanceOf(address(circuitBreaker)), 1_000_000e18);
-        assertEq(token.balanceOf(address(deFi)), 1_000_000e18 - uint256(withdrawalAmount1) - uint256(withdrawalAmount2));
-        assertEq(token.balanceOf(recipient), uint256(withdrawalAmount2));
+        circuitBreaker.migrateFundsAfterExploit(tokens, address(bob));
+        assertEq(token.balanceOf(address(bob)), uint256(withdrawalAmount));
     }
 }


### PR DESCRIPTION
I liked the way you refactored the tests, but the token claiming functions after a hack I felt needed some work, let me know what you think of this approach:

- Converting functions to one migrate tokens function
- adding isExploited flag to contract and reverts on future user actions as the admin should migrate all funds from protocol/circuit breaker to a new address to do a pro-rata distribution based on their protocols design
